### PR TITLE
Parsed out urls from kingsschool index.hbs

### DIFF
--- a/.dnsproxyrc
+++ b/.dnsproxyrc
@@ -9,8 +9,11 @@
     "/hs-analytics\\.net$/": "127.0.0.1",
     "/ads-twitter\\.com$/": "127.0.0.1",
     "/facebook\\.net$/": "127.0.0.1",
+    "/facebook\\.com$/": "127.0.0.1",
     "/adroll\\.com$/": "127.0.0.1",
-    "/linkedin\\.com$/": "127.0.0.1"
+    "/linkedin\\.com$/": "127.0.0.1",
+    "/licdn\\.com$/": "127.0.0.1",
+    "/quora\\.com$/": "127.0.0.1"
   },
   "api": {
     "enabled": true,


### PR DESCRIPTION
```
> fileData.match(reg).map(u => url.parse(u).hostname)
[
  'www.googletagmanager.com',
  'www.googletagmanager.com',
  'snap.licdn.com',
  'a.quora.com',
  'q.quora.com',
  'connect.facebook.net',
  'www.facebook.com',
  's.adroll.com',
  'a.adroll.com'
]
```

Added missing domain to list to resolve to loopback